### PR TITLE
Do not assume all pair_coeff come with a path

### DIFF
--- a/calphy/input.py
+++ b/calphy/input.py
@@ -55,10 +55,13 @@ def fix_paths(potlist):
     fixedpots = []
     for pot in potlist:
         pcraw = pot.split()
-        filename = pcraw[2]
-        filename = os.path.abspath(filename)
-        pcnew = " ".join([*pcraw[:2], filename, *pcraw[3:]])
-        fixedpots.append(pcnew)
+        if len(pcraw) >= 3:
+            filename = pcraw[2]
+            filename = os.path.abspath(filename)
+            pcnew = " ".join([*pcraw[:2], filename, *pcraw[3:]])
+            fixedpots.append(pcnew)
+        else:
+            fixedpots.append(pcraw)
         #print(pcnew)
     return fixedpots
     


### PR DESCRIPTION
At least for MTP potentials the format for the lammps potential is like

pair_style mlip mlip.ini
pair_coeff * *

where mlip.ini is the potential specific file.  That means when
fix_paths tries to look a filepath to adjust in pair_coeff it won't find
anything and crash.  This also means fix_paths might have to be applied
to pair_style also, but I haven't done that here. :/

I could not test further if there's issues with MTPs, because I'll need to custom build the lammps python first, so I am not sure if this change is the best way about it, but at least this quick fix got me somewhere calphy actually starts to try and run a calculation.