### PR TITLE
Allow  custom cmdargs for lammps object

### DIFF
--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -75,7 +75,7 @@ class Alchemy(cph.Phase):
         Fix lattice option is not implemented at present.
         At the end of the run, the averaged box dimensions are calculated. 
         """
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         #set up structure
         lmp = ph.create_structure(lmp, self.calc)
@@ -137,7 +137,7 @@ class Alchemy(cph.Phase):
         """
 
         #create lammps object
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
         
         # Adiabatic switching parameters.
         lmp.command("variable        li       equal   1.0")

--- a/calphy/helpers.py
+++ b/calphy/helpers.py
@@ -32,7 +32,7 @@ from ase.io import read, write
 from pyscal.trajectory import Trajectory
 
 
-def create_object(cores, directory, timestep):
+def create_object(cores, directory, timestep, cmdargs=None):
     """
     Create LAMMPS object
 
@@ -52,7 +52,7 @@ def create_object(cores, directory, timestep):
     lmp : LammpsLibrary object
     """
     lmp = LammpsLibrary(mode="local", cores=cores, 
-        working_directory=directory)
+        working_directory=directory, cmdargs=cmdargs)
     
     lmp.units("metal")
     lmp.boundary("p p p")

--- a/calphy/input.py
+++ b/calphy/input.py
@@ -186,6 +186,7 @@ class Calculation(InputTemplate):
         self.md.n_cycles = 100
         self.md.thermostat_damping = 0.1
         self.md.barostat_damping = 0.1
+        self.md.cmdargs = None
 
         self.nose_hoover = InputTemplate()
         self.nose_hoover.thermostat_damping = 0.1

--- a/calphy/input.py
+++ b/calphy/input.py
@@ -587,7 +587,7 @@ class Calculation(InputTemplate):
                 pcnew = " ".join([*pcraw[:2], filename, *pcraw[3:]])
                 fixedpots.append(pcnew)
             else:
-                fixedpots.append(pcraw)
+                fixedpots.append(pot)
         return fixedpots
     
     def create_identifier(self):

--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -112,7 +112,7 @@ class Liquid(cph.Phase):
         At the end of the run, the averaged box dimensions are calculated. 
         """
         #create lammps object
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         #set up structure
         lmp = ph.create_structure(lmp, self.calc, species=self.calc.n_elements+self.calc._ghost_element_count)
@@ -171,7 +171,7 @@ class Liquid(cph.Phase):
         Run the integration routine where the initial and final systems are connected using
         the lambda parameter. See algorithm 4 in publication.
         """
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         # Adiabatic switching parameters.
         lmp.command("variable        li       equal   1.0")

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -660,7 +660,7 @@ class Phase:
         pf = lf*pi
 
         #create lammps object
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         lmp.command("echo              log")
         lmp.command("variable          li equal %f"%li)
@@ -835,7 +835,7 @@ class Phase:
         pf = lf*p0
 
         #create lammps object
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         lmp.command("echo              log")
         lmp.command("variable          li equal %f"%li)
@@ -919,7 +919,7 @@ class Phase:
         pf = self.calc._pressure_stop
 
         #create lammps object
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         lmp.command("echo              log")
         lmp.command("variable          li equal %f"%li)

--- a/calphy/solid.py
+++ b/calphy/solid.py
@@ -136,7 +136,7 @@ class Solid(cph.Phase):
         is calculated.
         At the end of the run, the averaged box dimensions are calculated. 
         """
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         #set up structure
         lmp = ph.create_structure(lmp, self.calc, species=self.calc.n_elements+self.calc._ghost_element_count)
@@ -206,7 +206,7 @@ class Solid(cph.Phase):
         Run the integration routine where the initial and final systems are connected using
         the lambda parameter. See algorithm 4 in publication.
         """
-        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep)
+        lmp = ph.create_object(self.cores, self.simfolder, self.calc.md.timestep, self.calc.md.cmdargs)
 
         #read in the conf file
         conf = os.path.join(self.simfolder, "conf.equilibration.dump")

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - openmpi 
   - mpi4py
   - lammps =2022.06.23=*openmpi*_0
-  - pylammpsmpi =0.0.8
+  - pylammpsmpi
   - pyscal
   - matplotlib
   - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - openmpi 
   - mpi4py
   - lammps =2022.06.23=*openmpi*_0
-  - pylammpsmpi
+  - pylammpsmpi >=0.0.9
   - pyscal
   - matplotlib
   - tqdm


### PR DESCRIPTION
Allows to add a cmdargs str to the MD block that is passed to the lammps object. This in turn allows to use accelerator packages for lammps, f.e. -sf intel or -sf kokkos

Also attempts to fix issues with potentials like MTP which only use "* *" as pair_coeff str by adding it directly to the list. The prrevious implementation tried to pass the str '["*", "*"]' to lammps  which obviously does not work.