### PR TITLE
Allow pair styles with additional options

### DIFF
--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -194,8 +194,11 @@ class Alchemy(cph.Phase):
             pc2 = " ".join([*pcraw[:2], *[self.calc.pair_style[1],], *pcraw[2:]])
 
 
-        lmp.command("pair_style       hybrid/scaled v_flambda %s %s v_blambda %s %s"%(self.calc.pair_style_with_options[0], self.calc._p 
-            self.calc.pair_style_with_options[1]))
+        lmp.command("pair_style       hybrid/scaled v_flambda %s %s v_blambda %s %s"%(
+            self.calc.pair_style_with_options[0],
+            self.calc.pair_style_with_options[1]
+            )
+        )
         lmp.command("pair_coeff       %s"%pc1)
         lmp.command("pair_coeff       %s"%pc2)
 

--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -194,8 +194,8 @@ class Alchemy(cph.Phase):
             pc2 = " ".join([*pcraw[:2], *[self.calc.pair_style[1],], *pcraw[2:]])
 
 
-        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda %s"%(self.calc.pair_style[0], 
-            self.calc.pair_style[1]))
+        lmp.command("pair_style       hybrid/scaled v_flambda %s %s v_blambda %s %s"%(self.calc.pair_style_with_options[0], self.calc._p 
+            self.calc.pair_style_with_options[1]))
         lmp.command("pair_coeff       %s"%pc1)
         lmp.command("pair_coeff       %s"%pc2)
 
@@ -230,7 +230,7 @@ class Alchemy(cph.Phase):
         lmp.command("uncompute       c2")
 
 
-        lmp.command("pair_style      %s"%self.calc.pair_style[1])
+        lmp.command("pair_style      %s"%self.calc.pair_style_with_options[1])
         lmp.command("pair_coeff      %s"%self.calc.pair_coeff[1])
 
         # Thermo output.
@@ -246,8 +246,8 @@ class Alchemy(cph.Phase):
         lmp.command("variable         blambda equal ramp(${li},${lf})")
         
         
-        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda %s"%(self.calc.pair_style[0], 
-            self.calc.pair_style[1]))
+        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda %s"%(self.calc.pair_style_with_options[0], 
+            self.calc.pair_style_with_options[1]))
         lmp.command("pair_coeff       %s"%pc1)
         lmp.command("pair_coeff       %s"%pc2)
 

--- a/calphy/helpers.py
+++ b/calphy/helpers.py
@@ -125,7 +125,7 @@ def set_potential(lmp, options, ghost_elements=0):
     -------
     lmp : LammpsLibrary object
     """
-    lmp.pair_style(options.pair_style[0])
+    lmp.pair_style(options.pair_style_with_options[0])
     lmp.pair_coeff(options.pair_coeff[0])
 
     lmp = set_mass(lmp, options, ghost_elements=ghost_elements)
@@ -173,9 +173,9 @@ def get_structures(file, species, index=None):
 def set_hybrid_potential(lmp, options, eps, ghost_elements=0):
     pc =  options.pair_coeff[0]
     pcraw = pc.split()
-    pcnew = " ".join([*pcraw[:2], *[options.pair_style[0],], *pcraw[2:]])
+    pcnew = " ".join([*pcraw[:2], *[options.pair_style_with_options[0],], *pcraw[2:]])
     
-    lmp.command("pair_style       hybrid/overlay %s ufm 7.5"%options.pair_style[0])
+    lmp.command("pair_style       hybrid/overlay %s ufm 7.5"%options.pair_style_with_options[0])
     lmp.command("pair_coeff       %s"%pcnew)
     lmp.command("pair_coeff       * * ufm %f 1.5"%eps) 
 
@@ -183,22 +183,22 @@ def set_hybrid_potential(lmp, options, eps, ghost_elements=0):
 
     return lmp
 
-def set_double_hybrid_potential(lmp, options, pair_style, pair_coeff, ghost_elements=0):
+def set_double_hybrid_potential(lmp, options, ghost_elements=0):
     
-    pc1 =  pair_coeff[0]
+    pc1 =  options.pair_coeff[0]
     pcraw1 = pc1.split()
     
-    pc2 =  pair_coeff[1]
+    pc2 =  options.pair_coeff[1]
     pcraw2 = pc2.split()
 
-    if pair_style[0] == pair_style[1]:
-        pcnew1 = " ".join([*pcraw1[:2], *[pair_style[0],], "1", *pcraw1[2:]])
-        pcnew2 = " ".join([*pcraw2[:2], *[pair_style[1],], "2", *pcraw2[2:]])
+    if options.pair_style[0] == options.pair_style[1]:
+        pcnew1 = " ".join([*pcraw1[:2], *[options.pair_style[0],], "1", *pcraw1[2:]])
+        pcnew2 = " ".join([*pcraw2[:2], *[options.pair_style[1],], "2", *pcraw2[2:]])
     else:
-        pcnew1 = " ".join([*pcraw1[:2], *[pair_style[0],], *pcraw1[2:]])
-        pcnew2 = " ".join([*pcraw2[:2], *[pair_style[1],], *pcraw2[2:]])
+        pcnew1 = " ".join([*pcraw1[:2], *[options.pair_style[0],], *pcraw1[2:]])
+        pcnew2 = " ".join([*pcraw2[:2], *[options.pair_style[1],], *pcraw2[2:]])
 
-    lmp.command("pair_style       hybrid/overlay %s %s"%(pair_style[0], pair_style[1]))
+    lmp.command("pair_style       hybrid/overlay %s %s"%(options.pair_style_with_options[0], options.pair_style_with_options[1]))
     
     lmp.command("pair_coeff       %s"%pcnew1)
     lmp.command("pair_coeff       %s"%pcnew2) 

--- a/calphy/input.py
+++ b/calphy/input.py
@@ -432,6 +432,11 @@ class Calculation(InputTemplate):
     @property
     def pair_style(self):
         return self._pair_style
+
+    @property
+    def pair_style_with_options(self):
+        return [" ".join([self.pair_style[i], self._pair_style_options[i]]) for i in range(len(self.pair_style))]
+
     
     @pair_style.setter
     def pair_style(self, val):

--- a/calphy/input.py
+++ b/calphy/input.py
@@ -159,6 +159,7 @@ class Calculation(InputTemplate):
         self._fix_lattice = False
         self._melting_cycle = True
         self._pair_style = None
+        self._pair_style_options = None
         self._pair_coeff = None
         self._potential_file = None
         self._fix_potential_path = True
@@ -435,8 +436,19 @@ class Calculation(InputTemplate):
     @pair_style.setter
     def pair_style(self, val):
         val = self.check_and_convert_to_list(val)
+        ps_lst = []
+        ps_options_lst = []
+        for ps in val:
+            ps_split = ps.split()
+            ps_lst.append(ps_split[0])
+            if len(ps) > 1:
+                ps_options_lst.append(" ".join(ps_split[1:]))
+            else:
+                ps_options_lst.append("")
+
         #val = self.fix_paths(val)
-        self._pair_style = val
+        self._pair_style = ps_lst
+        self._pair_style_options = ps_options_lst
 
     @property
     def pair_coeff(self):

--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -204,7 +204,7 @@ class Liquid(cph.Phase):
         lmp.command("variable         flambda equal ramp(${li},${lf})")
         lmp.command("variable         blambda equal 1.0-v_flambda")
 
-        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"%self.calc.pair_style[0])
+        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"%self.calc.pair_style_with_options[0])
 
         pc =  self.calc.pair_coeff[0]
         pcraw = pc.split()
@@ -268,7 +268,7 @@ class Liquid(cph.Phase):
         lmp.command("variable         flambda equal ramp(${lf},${li})")
         lmp.command("variable         blambda equal 1.0-v_flambda")
 
-        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"%self.calc.pair_style[0])
+        lmp.command("pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"%self.calc.pair_style_with_options[0])
 
         lmp.command("pair_coeff       %s"%pcnew)
         lmp.command("pair_coeff       * * ufm %f 1.5"%self.eps)

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -163,12 +163,12 @@ class Phase:
 
         #now manually tune pair styles
         if self.calc.pair_style is not None:
-            self.logger.info("pair_style: %s"%self.calc.pair_style[0])
+            self.logger.info("pair_style: %s"%self.calc.pair_style_with_options[0])
             self.logger.info("pair_coeff: %s"%self.calc.pair_coeff[0])
 
             #log second pair style
             if len(self.calc.pair_style)>1:
-                self.logger.info("second pair_style: %s"%self.calc.pair_style[1])
+                self.logger.info("second pair_style: %s"%self.calc.pair_style_with_options[1])
                 self.logger.info("second pair_coeff: %s"%self.calc.pair_coeff[1])
         else:
             self.logger.info("pair_style or pair_coeff not provided")
@@ -726,7 +726,7 @@ class Phase:
         pcnew1 = " ".join([*pcraw[:2], *[self.calc.pair_style[0],], "1", *pcraw[2:]])
         pcnew2 = " ".join([*pcraw[:2], *[self.calc.pair_style[0],], "2", *pcraw[2:]])
 
-        lmp.command("pair_style       hybrid/scaled v_one %s v_fscale %s"%(self.calc.pair_style[0], self.calc.pair_style[0]))
+        lmp.command("pair_style       hybrid/scaled v_one %s v_fscale %s"%(self.calc.pair_style_with_options[0], self.calc.pair_style_with_options[0]))
         lmp.command("pair_coeff       %s"%pcnew1)
         lmp.command("pair_coeff       %s"%pcnew2)
 
@@ -764,7 +764,7 @@ class Phase:
         lmp.command("variable         bscale equal v_blambda-1.0")
         lmp.command("variable         one equal 1.0")
 
-        lmp.command("pair_style       hybrid/scaled v_one %s v_bscale %s"%(self.calc.pair_style[0], self.calc.pair_style[0]))
+        lmp.command("pair_style       hybrid/scaled v_one %s v_bscale %s"%(self.calc.pair_style_with_options[0], self.calc.pair_style_with_options[0]))
         lmp.command("pair_coeff       %s"%pcnew1)
         lmp.command("pair_coeff       %s"%pcnew2)
 


### PR DESCRIPTION
Pair styles requiring additional settings (everything with pair_style style args, f.e. pace recursive or  lj/long/coul/long cut off 2.5) caused problems when calling hybrid pair_style because the whole line was added.

This pr splits pair styles into the style and args, writing both when directly calling the pair style, but only the style when used in hybrid/scaled or computes. Therefore the user input is split() into styles and args and a pair_style_with_options property is added to the Calculation class that reconstructs the full string.