### PR TITLE
fix ufm params

### DIFF
--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -244,8 +244,8 @@ class Liquid(cph.Phase):
         lmp.command("variable         blambda equal 1.0-v_flambda")
 
         lmp.command(
-            "pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"
-            % self.calc._pair_style_with_options[0]
+            "pair_style       hybrid/scaled v_flambda %s v_blambda ufm %f"
+            % (self.calc._pair_style_with_options[0], self.ufm_cutoff)
         )
 
         pc = self.calc.pair_coeff[0]
@@ -261,7 +261,10 @@ class Liquid(cph.Phase):
         )
 
         lmp.command("pair_coeff       %s" % pcnew)
-        lmp.command("pair_coeff       * * ufm %f 1.5" % self.eps)
+        lmp.command(
+            "pair_coeff       * * ufm %f %f"
+            % (self.eps, self.calc.uhlenbeck_ford_model.sigma)
+        )
 
         lmp.command("compute          c1 all pair %s" % self.calc._pair_style_names[0])
         lmp.command("compute          c2 all pair ufm")
@@ -341,8 +344,8 @@ class Liquid(cph.Phase):
         lmp.command("variable         blambda equal 1.0-v_flambda")
 
         lmp.command(
-            "pair_style       hybrid/scaled v_flambda %s v_blambda ufm 7.5"
-            % self.calc._pair_style_with_options[0]
+            "pair_style       hybrid/scaled v_flambda %s v_blambda ufm %f"
+            % (self.calc._pair_style_with_options[0], self.ufm_cutoff)
         )
 
         lmp.command("pair_coeff       %s" % pcnew)


### PR DESCRIPTION
This pull request updates the `run_integration` method in `calphy/liquid.py` to improve flexibility and accuracy in defining simulation parameters. The changes primarily focus on making the `ufm` (Uhlenbeck-Ford model) parameters configurable through class attributes instead of hardcoding them.

Key changes to simulation parameter configuration:

* Updated the `pair_style` command to use the `ufm_cutoff` attribute instead of a hardcoded value [[1]](diffhunk://#diff-57754aa82b61708d302240d2f417fe4ab70b0c8b20b27b5f7d2fb47337e1153eL247-R248) [[2]](diffhunk://#diff-57754aa82b61708d302240d2f417fe4ab70b0c8b20b27b5f7d2fb47337e1153eL344-R348).
* Modified the `pair_coeff` command to include the `sigma` parameter from the `uhlenbeck_ford_model` attribute, making it more flexible and aligned with the model's configuration.