### PR TITLE
bug fix

### DIFF
--- a/calphy/phase_diagram.py
+++ b/calphy/phase_diagram.py
@@ -314,7 +314,10 @@ def prepare_inputs_for_phase_diagram(inputyamlfile, calculation_base_name=None):
 
         comps = phase['composition']
         reference_element = comps["reference_element"]
-        use_composition_scaling = bool(comps["use_composition_scaling"])
+        if "use_composition_scaling" in comps.keys():
+            use_composition_scaling = bool(comps["use_composition_scaling"])
+        else:
+            use_composition_scaling = True
         if str(phase_reference_state) == 'liquid':
             use_composition_scaling = False
 


### PR DESCRIPTION
This pull request introduces a conditional check for the `use_composition_scaling` key in the `comps` dictionary within the `prepare_inputs_for_phase_diagram` function in `calphy/phase_diagram.py`. If the key is not present, it defaults to `True`.

### Key change:

* **Enhancement to composition scaling logic**:
  - Added a conditional check to ensure the `use_composition_scaling` key is explicitly handled. If the key is missing, the code now defaults `use_composition_scaling` to `True`. This improves robustness by preventing potential `KeyError` exceptions.