### PR TITLE
Fix bug solid

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.2
+current_version = 1.4.3
 commit = True
 tag = True
 

--- a/calphy/__init__.py
+++ b/calphy/__init__.py
@@ -4,7 +4,7 @@ from calphy.solid import Solid
 from calphy.alchemy import Alchemy
 from calphy.routines import MeltingTemp
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 def addtest(a,b):
     return a+b

--- a/calphy/input.py
+++ b/calphy/input.py
@@ -48,7 +48,7 @@ from pyscal3.core import structure_dict, element_dict, _make_crystal
 from ase.io import read, write
 import shutil
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 
 def _check_equal(val):

--- a/calphy/solid.py
+++ b/calphy/solid.py
@@ -299,7 +299,7 @@ class Solid(cph.Phase):
             lmp.command(f'pair_style {self.calc._pair_style_with_options[0]}')
 
         #set up structure
-        lmp = ph.create_structure(lmp, self.calc, species=self.calc.n_elements+self.calc._ghost_element_count)
+        lmp = ph.create_structure(lmp, self.calc)
 
         if self.calc.potential_file is None:
             lmp.command(f'pair_coeff {self.calc.pair_coeff[0]}')

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(include=['calphy', 'calphy.*']),
     test_suite='tests',
     url='https://github.com/ICAMS/calphy',
-    version='1.4.2',
+    version='1.4.3',
     zip_safe=False,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This pull request includes a version update for the `calphy` package and a minor change in the `run_minimal_averaging` method in `calphy/solid.py`. The most important changes are grouped below:


### Code Simplification:
* Simplified the `run_minimal_averaging` method in `calphy/solid.py` by removing the redundant `species` argument when calling `ph.create_structure`.