### PR TITLE
Change all np.NaN to np.nan

### DIFF
--- a/calphy/postprocessing.py
+++ b/calphy/postprocessing.py
@@ -121,7 +121,7 @@ def gather_results(mainfolder, reduce_composition=True,
         #print(inpfile)
         if not os.path.exists(outfile):
             datadict['status'].append('False')
-            datadict['free_energy'].append(np.NaN)
+            datadict['free_energy'].append(np.nan)
             #check if error file is found
             errfile = os.path.join(os.getcwd(), mainfolder, folder+'.sub.err')
             datadict['error_code'][-1] = _extract_error(errfile)


### PR DESCRIPTION
This pull request includes a minor update to the `gather_results` function in `calphy/postprocessing.py`. The change replaces the use of `np.NaN` with `np.nan` for consistency in representing missing free energy values.