### PR TITLE
Add conditional import for trapz based on NumPy version

### DIFF
--- a/calphy/integrators.py
+++ b/calphy/integrators.py
@@ -129,8 +129,8 @@ def integrate_path(
     fdu = fdui - fdur
     bdu = bdui - bdur
 
-    fw = np.trapz(fdu, flambda)
-    bw = np.trapz(bdu, blambda)
+    fw = trapz(fdu, flambda)
+    bw = trapz(bdu, blambda)
 
     w = 0.5 * (fw - bw)
     q = 0.5 * (fw + bw)


### PR DESCRIPTION
Import trapz function conditionally based on NumPy version.

It's been finally removed in 2.4, but since numpy version is not restricted in pypi/conda packages, it's currently possible to end up with broken calphy installations.

https://numpy.org/doc/stable/release/2.4.0-notes.html#removal-of-deprecated-functions-and-arguments

