### PR TITLE
fix: melting_temperature crashes with n_iterations > 1

### DIFF
--- a/calphy/routines.py
+++ b/calphy/routines.py
@@ -190,9 +190,9 @@ class MeltingTemp:
                 self.logger.info("Solid system melted during reversible scaling run")
                 return 2
 
-            self.solres = self.soljob.integrate_reversible_scaling(
-                scale_energy=True, return_values=True
-            )
+        self.solres = self.soljob.integrate_reversible_scaling(
+            scale_energy=True, return_values=True
+        )
 
         self.logger.info("Starting liquid fe calculation")
         try:


### PR DESCRIPTION
fix: move integrate_reversible_scaling outside loop in MeltingTemp.run_jobs

When n_iterations > 1, integrate_reversible_scaling was called inside
the for loop before all ts.forward_N.dat files existed, causing
FileNotFoundError. Fixed by moving the call outside the loop.