### PR TITLE
Remove lattice: LQD from docs

### DIFF
--- a/docs/source/inputfile.md
+++ b/docs/source/inputfile.md
@@ -298,7 +298,6 @@ _default_: None \
 _example_:
 ```
 lattice: FCC
-lattice: [FCC, LQD]
 lattice: [FCC, conf.data]
 ```
    


### PR DESCRIPTION
As far as I can tell, the special string LQD is (no longer?) supported in calphy/input.py  It's not exactly needed, and the actual text doesn't mention it, but skimming the docs earlier I got the impression that it is an actual flag to use.