### PR TITLE
Make queue options a dict and write nicely

### DIFF
--- a/calphy/input.py
+++ b/calphy/input.py
@@ -22,7 +22,7 @@ sarath.menon@ruhr-uni-bochum.de/yury.lysogorskiy@icams.rub.de
 """
 
 from typing_extensions import Annotated
-from typing import Any, Callable, List, ClassVar, Optional, Union
+from typing import Any, Callable, Dict, List, ClassVar, Optional, Union
 from pydantic import (
     BaseModel,
     Field,
@@ -217,7 +217,7 @@ class Queue(BaseModel, title="Options for configuring queue"):
     queuename: Annotated[str, Field(default="")]
     memory: Annotated[str, Field(default="3GB")]
     commands: Annotated[List, Field(default=[])]
-    options: Annotated[List, Field(default=[])]
+    options: Annotated[Dict[str, str], Field(default={})]
 
 
 class Tolerance(BaseModel, title="Tolerance settings for convergence"):

--- a/calphy/scheduler.py
+++ b/calphy/scheduler.py
@@ -96,7 +96,7 @@ class SLURM:
             "cores": cores,
             "hint": "nomultithread",
             "directory": directory,
-            "options": [],
+            "options": {},
             "commands": [
                 "uss=$(whoami)",
                 "find /dev/shm/ -user $uss -type f -mmin +30 -delete",
@@ -132,8 +132,8 @@ class SLURM:
             fout.write("#SBATCH --chdir=%s\n" % self.queueoptions["directory"])
 
             # now write extra options
-            for option in self.queueoptions["options"]:
-                fout.write("#SBATCH %s\n" % option)
+            for key, value in self.queueoptions["options"].items():
+                fout.write(f"#SBATCH --{key}={value}\n")
 
             # now finally commands
             for command in self.queueoptions["commands"]:

--- a/docs/source/inputfile.md
+++ b/docs/source/inputfile.md
@@ -858,7 +858,7 @@ _type_: string \
 _example_:
 ```
 options:
-  - memory: 3GB
+  memory: 3GB
 ```
 
 Extra options to be added to the submission script.


### PR DESCRIPTION
Previously the 'options' key in the 'queue' block was expected to be a plain list of strings, like so

```
options:
 - "--account=myname"
```

Now it accepts

```
options:
 acount: myname
```

Both are different from the previously documented style

```
options:
 - acount: myname
```

which yields lists of dicts and messed up the writing logic.