### PR TITLE
Ensure unique slurm output files

### DIFF
--- a/calphy/scheduler.py
+++ b/calphy/scheduler.py
@@ -114,8 +114,8 @@ class SLURM:
         """
         Write the script file
         """
-        jobout = os.path.join(self.queueoptions["directory"], "slurm.out")
-        joberr = os.path.join(self.queueoptions["directory"], "slurm.err")
+        jobout = os.path.join(self.queueoptions["directory"], f"{outfile}.slurm.out")
+        joberr = os.path.join(self.queueoptions["directory"], f"{outfile}.slurm.err")
 
         with open(outfile, "w") as fout:
             fout.write(self.queueoptions["header"])


### PR DESCRIPTION
Without this calphy runs starting in the same directory, e.g. multiple calculations in one input yaml, overwrite each others slurm logs.