### PR TITLE
npz & new reports

### DIFF
--- a/calphy/integrators.py
+++ b/calphy/integrators.py
@@ -224,7 +224,7 @@ def integrate_rs(
 
     Notes
     -----
-    Writes the output in a file reversible_scaling.dat
+    Writes the output in a file temperature_sweep.dat and temperature_sweep.npz
 
     """
     ws = []
@@ -267,6 +267,8 @@ def integrate_rs(
     if not return_values:
         outfile = os.path.join(simfolder, "temperature_sweep.dat")
         np.savetxt(outfile, np.column_stack((temp, f, werr)))
+        outfile = os.path.join(simfolder, "temperature_sweep.npz")
+        np.savez_compressed(outfile, (temp, f, werr))
         return None, e_diss
     else:
         return (temp, f, werr), e_diss
@@ -291,7 +293,7 @@ def integrate_ps(simfolder, f0, natoms, pi, pf, nsims=1, return_values=False):
 
     Notes
     -----
-    Writes the output in a file pressure_sweep.dat
+    Writes the output in a file pressure_sweep.dat and pressure_sweep.npz
 
     """
 
@@ -327,6 +329,8 @@ def integrate_ps(simfolder, f0, natoms, pi, pf, nsims=1, return_values=False):
     if not return_values:
         outfile = os.path.join(simfolder, "pressure_sweep.dat")
         np.savetxt(outfile, np.column_stack((press, f, werr)))
+        outfile = os.path.join(simfolder, "pressure_sweep.npz")
+        np.savez_compressed(outfile, (press, f, werr))
     else:
         return (press, f, werr)
 

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -992,6 +992,17 @@ class Phase:
                 self.publications.append("10.1016/j.commatsci.2018.12.029")
                 self.publications.append("10.1063/1.4967775")
 
+    def submit_ts_report(self):
+        datafile = os.path.join(self.simfolder, "temperature_sweep.npz")
+        T, f, ferr = np.load(datafile).values()
+        report = {}
+        report["results"] = {}
+        report["temperature"] = T
+        report["free_energy"] = f
+        reportfile = os.path.join(self.simfolder, "report_ts.yaml")
+        with open(reportfile, "w") as f:
+            yaml.dump(report, f)
+
     def reversible_scaling(self, iteration=1):
         """
         Perform reversible scaling calculation in NPT

--- a/calphy/routines.py
+++ b/calphy/routines.py
@@ -392,6 +392,7 @@ def routine_ts(job):
         job.logger.info("TS integration cycle %d finished in %f s" % (i + 1, te))
 
     job.integrate_reversible_scaling(scale_energy=True)
+    job.submit_ts_report()
     job.clean_up()
     return job
 


### PR DESCRIPTION
Fixes #186 

Still toying around a bit here.  npz seems to save ~50% storage when I compressed some of the existing data I have around.  

I initially I thought we would add this data to the overall report, but it feels a bit awkward given its internal structure, so I left it in its own file for now and let you make that decision on how to integrate it.

I think this is actually also a nice time to upgrade the volume samples in the final outputs.  They can be read of the per iteration files, but it's a bit inconvenient.

Will also create a pressure report unless you have other plans.