### PR TITLE
Extend external LammpsLibrary interface 

### DIFF
--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -127,7 +127,10 @@ class Alchemy(cph.Phase):
 
         # close object and process traj
         lmp = ph.write_data(lmp, "conf.equilibration.data")
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -503,7 +506,10 @@ class Alchemy(cph.Phase):
             for idx in range(len(swap_combos)):
                 lmp.command(f"unfix swap{idx}")
             # lmp.command("unfix swap_print")
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:

--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -127,10 +127,7 @@ class Alchemy(cph.Phase):
 
         # close object and process traj
         lmp = ph.write_data(lmp, "conf.equilibration.data")
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -506,10 +503,7 @@ class Alchemy(cph.Phase):
             for idx in range(len(swap_combos)):
                 lmp.command(f"unfix swap{idx}")
             # lmp.command("unfix swap_print")
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:

--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -131,10 +131,7 @@ class Liquid(cph.Phase):
 
         # if melting cycle is over and still not melted, raise error
         if not melted:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -218,10 +215,7 @@ class Liquid(cph.Phase):
         self.check_if_solidfied(lmp, "traj.equilibration_stage1.dat")
         self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
         lmp = ph.write_data(lmp, "conf.equilibration.data")
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -443,10 +437,7 @@ class Liquid(cph.Phase):
         lmp.command("uncompute        c2")
 
         # close object
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:

--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -131,7 +131,10 @@ class Liquid(cph.Phase):
 
         # if melting cycle is over and still not melted, raise error
         if not melted:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -215,7 +218,10 @@ class Liquid(cph.Phase):
         self.check_if_solidfied(lmp, "traj.equilibration_stage1.dat")
         self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
         lmp = ph.write_data(lmp, "conf.equilibration.data")
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -437,7 +443,10 @@ class Liquid(cph.Phase):
         lmp.command("uncompute        c2")
 
         # close object
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -279,7 +279,10 @@ class Phase:
         """ """
         solids = ph.find_solid_fraction(os.path.join(self.simfolder, filename))
         if solids / lmp.natoms < self.calc.tolerance.solid_fraction:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -296,7 +299,10 @@ class Phase:
         """ """
         solids = ph.find_solid_fraction(os.path.join(self.simfolder, filename))
         if solids / lmp.natoms > self.calc.tolerance.liquid_fraction:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -611,7 +617,10 @@ class Phase:
             laststd = std
 
         if not converged:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -736,7 +745,10 @@ class Phase:
         lmp.command("unfix            2")
 
         if not converged:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -1249,7 +1261,10 @@ class Phase:
             lmp.command("undump           d1")
 
         # close the object
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):
@@ -1449,8 +1464,11 @@ class Phase:
         )
         lmp.command("run               %d" % self.calc._n_sweep_steps)
 
-        lmp.close()
-        # Preserve log file
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
+    # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):
             os.rename(
@@ -1587,7 +1605,10 @@ class Phase:
         )
         lmp.command("run               %d" % self.calc._n_sweep_steps)
 
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -279,10 +279,7 @@ class Phase:
         """ """
         solids = ph.find_solid_fraction(os.path.join(self.simfolder, filename))
         if solids / lmp.natoms < self.calc.tolerance.solid_fraction:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -299,10 +296,7 @@ class Phase:
         """ """
         solids = ph.find_solid_fraction(os.path.join(self.simfolder, filename))
         if solids / lmp.natoms > self.calc.tolerance.liquid_fraction:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -617,10 +611,7 @@ class Phase:
             laststd = std
 
         if not converged:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -745,10 +736,7 @@ class Phase:
         lmp.command("unfix            2")
 
         if not converged:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file on error
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:
@@ -1261,10 +1249,7 @@ class Phase:
             lmp.command("undump           d1")
 
         # close the object
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):
@@ -1464,10 +1449,7 @@ class Phase:
         )
         lmp.command("run               %d" % self.calc._n_sweep_steps)
 
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
     # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):
@@ -1605,10 +1587,7 @@ class Phase:
         )
         lmp.command("run               %d" % self.calc._n_sweep_steps)
 
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         if os.path.exists(logfile):
@@ -1664,3 +1643,9 @@ class Phase:
 
         with open(os.path.join(self.simfolder, "metadata.yaml"), "w") as fout:
             yaml.safe_dump(metadata, fout)
+
+    def lammps_close(self, lmp):
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()

--- a/calphy/solid.py
+++ b/calphy/solid.py
@@ -293,7 +293,10 @@ class Solid(cph.Phase):
         self.check_if_melted(lmp, "traj.equilibration_stage2.dat")
         lmp = ph.write_data(lmp, "conf.equilibration.data")
         # close object and process traj
-        lmp.close()
+        if self._lmp is None:
+            lmp.close()
+        else:
+            lmp.clear()
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -593,7 +596,10 @@ class Solid(cph.Phase):
 
         # close object
         if not self.calc.script_mode:
-            lmp.close()
+            if self._lmp is None:
+                lmp.close()
+            else:
+                lmp.clear()
             # Preserve log file
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:

--- a/calphy/solid.py
+++ b/calphy/solid.py
@@ -293,10 +293,7 @@ class Solid(cph.Phase):
         self.check_if_melted(lmp, "traj.equilibration_stage2.dat")
         lmp = ph.write_data(lmp, "conf.equilibration.data")
         # close object and process traj
-        if self._lmp is None:
-            lmp.close()
-        else:
-            lmp.clear()
+        self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
         try:
@@ -596,10 +593,7 @@ class Solid(cph.Phase):
 
         # close object
         if not self.calc.script_mode:
-            if self._lmp is None:
-                lmp.close()
-            else:
-                lmp.clear()
+            self.lammps_close(lmp=lmp)
             # Preserve log file
             logfile = os.path.join(self.simfolder, "log.lammps")
             try:


### PR DESCRIPTION
After some additional testing I noticed that the default setting of closing the LAMMPS library after a given simulation task is confusing when using an external LammpsLibrary interface. So in this pull request I propose to just clear the state of the library rather than closing the library interface completely. Still this comes at the cost that the user has to close the library at the end. 