### PR TITLE
Extend script_mode to liquid, alchemy, and mode:ts

### DIFF
--- a/calphy/alchemy.py
+++ b/calphy/alchemy.py
@@ -83,10 +83,11 @@ class Alchemy(cph.Phase):
         """
         lmp = ph.create_object(
             cores=self.cores,
-            directory=self.simfolder, 
-            timestep=self.calc.md.timestep, 
-            cmdargs=self.calc.md.cmdargs, 
-            init_commands=self.calc.md.init_commands, 
+            directory=self.simfolder,
+            timestep=self.calc.md.timestep,
+            cmdargs=self.calc.md.cmdargs,
+            init_commands=self.calc.md.init_commands,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -121,12 +122,19 @@ class Alchemy(cph.Phase):
             # routine in which lattice constant will not varied, but is set to a given fixed value
             self.run_constrained_pressure_convergence(lmp)
 
-        # check for melting
-        self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
-        self.check_if_melted(lmp, "traj.equilibration_stage2.dat")
+        if not self.calc.script_mode:
+            # check for melting
+            self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
+            self.check_if_melted(lmp, "traj.equilibration_stage2.dat")
 
         # close object and process traj
         lmp = ph.write_data(lmp, "conf.equilibration.data")
+
+        if self.calc.script_mode:
+            file = os.path.join(self.simfolder, "averaging.lmp")
+            lmp.write(file)
+            return
+
         self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
@@ -158,10 +166,11 @@ class Alchemy(cph.Phase):
         # create lammps object
         lmp = ph.create_object(
             cores=self.cores,
-            directory=self.simfolder, 
-            timestep=self.calc.md.timestep, 
-            cmdargs=self.calc.md.cmdargs, 
-            init_commands=self.calc.md.init_commands, 
+            directory=self.simfolder,
+            timestep=self.calc.md.timestep,
+            cmdargs=self.calc.md.cmdargs,
+            init_commands=self.calc.md.init_commands,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -503,6 +512,12 @@ class Alchemy(cph.Phase):
             for idx in range(len(swap_combos)):
                 lmp.command(f"unfix swap{idx}")
             # lmp.command("unfix swap_print")
+
+        if self.calc.script_mode:
+            file = os.path.join(self.simfolder, "integration.lmp")
+            lmp.write(file)
+            return
+
         self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")

--- a/calphy/helpers.py
+++ b/calphy/helpers.py
@@ -37,6 +37,17 @@ from pyscal3.trajectory import Trajectory
 
 
 class LammpsScript:
+    """Collect LAMMPS commands instead of executing them.
+
+    Mirrors a small subset of the ``pylammpsmpi.LammpsLibrary`` interface so the
+    same calphy code paths can either run LAMMPS in-process or emit a script
+    that is executed by an external ``lmp`` binary. Any unknown attribute is
+    treated as a LAMMPS command name and lowered to ``command(...)``.
+    """
+
+    # Methods that must NOT be auto-lowered to LAMMPS commands.
+    _RESERVED_NAMES = frozenset({"script", "command", "write", "close", "clear"})
+
     def __init__(self):
         self.script = []
 
@@ -47,6 +58,21 @@ class LammpsScript:
         with open(infile, "w") as fout:
             for line in self.script:
                 fout.write(f"{line}\n")
+
+    def close(self):
+        pass
+
+    def clear(self):
+        self.script = []
+
+    def __getattr__(self, name):
+        if name.startswith("_") or name in LammpsScript._RESERVED_NAMES:
+            raise AttributeError(name)
+
+        def _emit(*args):
+            self.command(" ".join([name, *(str(a) for a in args)]))
+
+        return _emit
 
 
 def create_object(

--- a/calphy/liquid.py
+++ b/calphy/liquid.py
@@ -167,6 +167,13 @@ class Liquid(cph.Phase):
         is calculated.
         At the end of the run, the averaged box dimensions are calculated.
         """
+        if self.calc.script_mode and self.calc.melting_cycle:
+            raise ValueError(
+                "melting_cycle requires Python-driven solid-fraction checks and "
+                "is not supported in script_mode. Use rattle (melting_cycle: False) "
+                "or run with script_mode: False."
+            )
+
         # create lammps object
         lmp = ph.create_object(
             cores=self.cores,
@@ -174,6 +181,7 @@ class Liquid(cph.Phase):
             timestep=self.calc.md.timestep,
             cmdargs=self.calc.md.cmdargs,
             init_commands=self.calc.md.init_commands,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -213,11 +221,18 @@ class Liquid(cph.Phase):
         else:
             self.run_constrained_pressure_convergence(lmp)
 
-        # check melted error
-        self.dump_current_snapshot(lmp, "traj.equilibration_stage1.dat")
-        self.check_if_solidfied(lmp, "traj.equilibration_stage1.dat")
-        self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
+        if not self.calc.script_mode:
+            # check melted error
+            self.dump_current_snapshot(lmp, "traj.equilibration_stage1.dat")
+            self.check_if_solidfied(lmp, "traj.equilibration_stage1.dat")
+            self.dump_current_snapshot(lmp, "traj.equilibration_stage2.dat")
         lmp = ph.write_data(lmp, "conf.equilibration.data")
+
+        if self.calc.script_mode:
+            file = os.path.join(self.simfolder, "averaging.lmp")
+            lmp.write(file)
+            return
+
         self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
@@ -250,6 +265,7 @@ class Liquid(cph.Phase):
             timestep=self.calc.md.timestep,
             cmdargs=self.calc.md.cmdargs,
             init_commands=self.calc.md.init_commands,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -444,6 +460,11 @@ class Liquid(cph.Phase):
         for compute_id in compute_ids:
             lmp.command("uncompute        %s" % compute_id)
         lmp.command("uncompute        c2")
+
+        if self.calc.script_mode:
+            file = os.path.join(self.simfolder, "integration.lmp")
+            lmp.write(file)
+            return
 
         # close object
         self.lammps_close(lmp=lmp)

--- a/calphy/phase.py
+++ b/calphy/phase.py
@@ -1024,7 +1024,7 @@ class Phase:
             timestep=self.calc.md.timestep,
             cmdargs=self.calc.md.cmdargs,
             init_commands=self.calc.md.init_commands,
-            script_mode=False,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -1298,6 +1298,16 @@ class Phase:
         if self.calc.n_print_steps > 0:
             lmp.command("undump           d1")
 
+        if self.calc.script_mode:
+            file = os.path.join(
+                self.simfolder, "reversible_scaling_%d.lmp" % iteration
+            )
+            lmp.write(file)
+            self.logger.info("Please cite the following publications:")
+            self.logger.info("- 10.1103/PhysRevLett.83.3973")
+            self.publications.append("10.1103/PhysRevLett.83.3973")
+            return
+
         # close the object
         self.lammps_close(lmp=lmp)
         # Preserve log file
@@ -1381,7 +1391,7 @@ class Phase:
             timestep=self.calc.md.timestep,
             cmdargs=self.calc.md.cmdargs,
             init_commands=self.calc.md.init_commands,
-            script_mode=False,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 
@@ -1495,6 +1505,13 @@ class Phase:
         )
         lmp.command("run               %d" % self.calc._n_sweep_steps)
 
+        if self.calc.script_mode:
+            file = os.path.join(
+                self.simfolder, "temperature_scaling_%d.lmp" % iteration
+            )
+            lmp.write(file)
+            return
+
         self.lammps_close(lmp=lmp)
         # Preserve log file
         logfile = os.path.join(self.simfolder, "log.lammps")
@@ -1529,7 +1546,7 @@ class Phase:
             timestep=self.calc.md.timestep,
             cmdargs=self.calc.md.cmdargs,
             init_commands=self.calc.md.init_commands,
-            script_mode=False,
+            script_mode=self.calc.script_mode,
             lmp=self._lmp,
         )
 


### PR DESCRIPTION
## Summary

Currently `script_mode: true` only works for `mode: fe` with `reference_phase: solid`. For other phases/modes the code unconditionally constructs a `pylammpsmpi.LammpsLibrary` — which requires LAMMPS built as a shared library with Python bindings (`PKG_PYTHON=ON`, `BUILD_LIB=ON`, `BUILD_SHARED_LIBS=ON`).

This is restrictive for users running ML interatomic potentials whose LAMMPS plugins ship only as a regular executable build (e.g. `pair_grace` against a TensorFlow SavedModel; `pair_mace`; etc.). For these the natural workflow is `script_mode: true` + `lammps_executable: <path>` — calphy emits a `.lmp` script and the user's `lmp` runs it.

This PR extends that workflow to **liquid**, **alchemy**, and **`mode: ts`** so they all honour `script_mode: true` end-to-end and shell out via `lammps_executable`.

## Changes

1. **Extend script_mode to liquid and alchemy phases** (1cd7612)
   - `helpers.py`: `LammpsScript` gains a `__getattr__` polyfill so unknown attributes (e.g. `lmp.velocity(...)`, `lmp.run(N)`) lower to the equivalent `command(...)` call. Lets the liquid/alchemy routines use the same Python-style API as the in-process `LammpsLibrary` path without each call site needing two branches.
   - `liquid.py`: propagate `script_mode` into the LAMMPS factory; emit `averaging.lmp` and `integration.lmp` at the end of each routine when in script mode.
   - `alchemy.py`: same propagation pattern.

2. **Extend script_mode to mode:ts** (76b0ad7)
   - `phase.py`: `reversible_scaling` and `temperature_scaling` were the last sites hardcoding `script_mode=False`; replace with `script_mode=self.calc.script_mode` and write the resulting `reversible_scaling_<i>.lmp` / `temperature_scaling_<i>.lmp`.

Default behaviour is unchanged: `script_mode` still defaults to `false`, all existing in-process workflows go through the same `LammpsLibrary` path as before.

## Tests

`pytest tests/` — all 96 existing tests pass on this branch.

The branch is based on commit 0911ac4; `main` has since moved 9 commits ahead (`phase_diagram.py` rework + version bump 1.7.2 → 1.7.3 + tdb test renames). None of the upstream changes touch the files modified here (`phase.py`, `liquid.py`, `alchemy.py`, `helpers.py`), so this should merge cleanly — happy to rebase if preferred.

## Out-of-band validation

Used to drive a 48-potential calphy `mode: ts` campaign computing F(T) BCC/FCC for GRACE Fe ML interatomic potentials against a custom LAMMPS binary that doesn't have Python bindings.
