### PR TITLE
Add gres and account fields to scheduler configuration

### DIFF
--- a/calphy/scheduler.py
+++ b/calphy/scheduler.py
@@ -95,6 +95,8 @@ class SLURM:
             "memory": None,
             "cores": cores,
             "cpus_per_task": None,
+            "gres": None,
+            "account": None,
             "hint": "nomultithread",
             "directory": directory,
             "options": {},


### PR DESCRIPTION
I added the `gres` and `account` Slurm flags to the `SLURM` class for easy access, rather than just having to rely on `options`.